### PR TITLE
Update bevy_rapier downstream to a newer commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ checksum = "c77ec20c8fafcdc196508ef5ccb4f0400a8d193cb61f7b14a36ed9a25ad423cf"
 [[package]]
 name = "bevy_rapier3d"
 version = "0.23.0"
-source = "git+https://github.com/liquidev/bevy_rapier?branch=glass-transition-downstream#9f060aafeedf03a8e2c1aacd0f1f33f1192542c9"
+source = "git+https://github.com/liquidev/bevy_rapier?rev=5b1f4f56627fb1a1a715ccd7914d3775e31b8dd3#5b1f4f56627fb1a1a715ccd7914d3775e31b8dd3"
 dependencies = [
  "bevy",
  "bitflags 2.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ dynamic-linking = ["bevy/dynamic_linking"]
 
 [dependencies]
 bevy = { version = "0.12.1", features = ["file_watcher"] }
-bevy_rapier3d = { git = "https://github.com/liquidev/bevy_rapier", branch = "glass-transition-downstream" }
+bevy_rapier3d = { git = "https://github.com/liquidev/bevy_rapier", rev = "5b1f4f56627fb1a1a715ccd7914d3775e31b8dd3" }
 bevy_egui = "0.24.0"
 bevy_replicon = "0.18.1"
 egui_plot = "0.24.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,14 +31,6 @@ fn main() {
                 }),
         )
         .add_plugins(bevy_egui::EguiPlugin)
-        .insert_resource(RapierConfiguration {
-            timestep_mode: TimestepMode::Interpolated {
-                dt: TIMESTEP as f32,
-                time_scale: 1.0,
-                substeps: 4,
-            },
-            ..default()
-        })
         .add_plugins(RapierPhysicsPlugin::<()>::default().with_physics_scale(1.0))
         .add_plugins(RapierDebugRenderPlugin {
             enabled: false,


### PR DESCRIPTION
Branches may change, and it's hard for cargo to detect that when the Cargo.toml doesn't change. Therefore from now on the dependency is specified in terms of a rev rather than a branch.