### PR TITLE
Reworking the developer tool menus

### DIFF
--- a/src/developer_tools/mod.rs
+++ b/src/developer_tools/mod.rs
@@ -1,17 +1,58 @@
 use bevy::prelude::*;
+use bevy_egui::{egui, EguiContexts};
 
 use self::prototype_material::PrototypeMaterial;
 
-pub mod cheat_menu;
 pub mod prototype_material;
+pub mod spawn;
 pub mod time;
 
 pub struct DeveloperToolsPlugin;
 
 impl Plugin for DeveloperToolsPlugin {
     fn build(&self, app: &mut App) {
+        // Plugins
         app.add_plugins(MaterialPlugin::<PrototypeMaterial>::default())
             .add_plugins(time::TimePlugin)
-            .add_plugins(cheat_menu::CheatMenuPlugin);
+            .add_plugins(spawn::SpawnPlugin);
+
+        // Developer tools debug menu
+        app.insert_resource(DeveloperTools {
+            hub: cfg!(debug_assertions),
+            ..default()
+        })
+        .add_systems(Update, toggle_hub_ui)
+        .add_systems(Update, hub_ui.run_if(tool_enabled(|tools| tools.hub)));
     }
+}
+
+/// Resource which stores which developer tools are currently enabled.
+#[derive(Debug, Clone, Resource, Default)]
+pub struct DeveloperTools {
+    pub hub: bool,
+
+    pub spawn: bool,
+    pub time: bool,
+}
+
+pub fn tool_enabled(
+    f: fn(&DeveloperTools) -> bool,
+) -> impl Fn(Res<DeveloperTools>) -> bool + Clone {
+    move |developer_tools| developer_tools.hub && f(&developer_tools)
+}
+
+fn toggle_hub_ui(mut tools: ResMut<DeveloperTools>, input: Res<Input<KeyCode>>) {
+    if input.just_pressed(KeyCode::Grave) {
+        tools.hub = !tools.hub;
+    }
+}
+
+fn hub_ui(mut tools: ResMut<DeveloperTools>, mut ctx: EguiContexts) {
+    egui::Window::new("Developer Tools").show(ctx.ctx_mut(), |ui| {
+        ui.horizontal_wrapped(|ui| {
+            // Please keep these sorted alphabetically!
+            ui.toggle_value(&mut tools.spawn, "Spawn");
+            ui.toggle_value(&mut tools.time, "Time");
+        });
+    });
 }

--- a/src/developer_tools/time.rs
+++ b/src/developer_tools/time.rs
@@ -5,13 +5,16 @@ use bevy_egui::{
     egui::{self, Slider},
     EguiContexts,
 };
-use egui_plot::{Line, Plot, PlotPoints};
+use egui_plot::{Legend, Line, Plot, PlotPoints};
+
+use super::tool_enabled;
 
 pub struct TimePlugin;
 
 impl Plugin for TimePlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<TimeGraph>().add_systems(Update, ui);
+        app.init_resource::<TimeGraph>()
+            .add_systems(Update, ui.run_if(tool_enabled(|tools| tools.time)));
     }
 }
 
@@ -44,22 +47,31 @@ pub fn ui(
     time_graph.update(real_time.delta_seconds());
 
     egui::Window::new("Time").show(ctx.ctx_mut(), |ui| {
-        let mut timestep_hz = 1.0 / fixed_time.timestep().as_secs_f64();
-        ui.add(Slider::new(&mut timestep_hz, 1.0..=144.0).text("Timestep"));
-        fixed_time.set_timestep_hz(timestep_hz);
+        ui.horizontal(|ui| {
+            let mut timestep_hz = 1.0 / fixed_time.timestep().as_secs_f64();
+            ui.label("Timestep");
+            ui.add(Slider::new(&mut timestep_hz, 1.0..=144.0));
+            ui.end_row();
+            fixed_time.set_timestep_hz(timestep_hz);
+        });
 
-        let plot_points = PlotPoints::from_parametric_callback(
-            |x| (x, time_graph.delta_time[x as usize] as f64 * 1000.0),
-            0.0..=(time_graph.delta_time.len() - 1) as f64,
-            time_graph.delta_time.len(),
-        );
-        Plot::new("delta_time")
-            .include_x(0.0)
-            .include_x(time_graph.delta_time.len() as f64)
-            .include_y(0.0)
-            .include_y(20.0)
-            .view_aspect(3.0)
-            .height(128.0)
-            .show(ui, |plot_ui| plot_ui.line(Line::new(plot_points)));
+        ui.horizontal(|ui| {
+            let plot_points = PlotPoints::from_parametric_callback(
+                |x| (x, time_graph.delta_time[x as usize] as f64 * 1000.0),
+                0.0..=(time_graph.delta_time.len() - 1) as f64,
+                time_graph.delta_time.len(),
+            );
+            Plot::new("delta_time")
+                .include_x(0.0)
+                .include_x(time_graph.delta_time.len() as f64)
+                .include_y(0.0)
+                .include_y(20.0)
+                .view_aspect(3.0)
+                .height(128.0)
+                .legend(Legend::default())
+                .show(ui, |plot_ui| {
+                    plot_ui.line(Line::new(plot_points).name("Frame time"))
+                });
+        });
     });
 }


### PR DESCRIPTION
There's now a central hub for toggling developer tools on and off. Developer tools are only visible only in case the main hub is shown.